### PR TITLE
Fix Apache class matcher

### DIFF
--- a/disco-java-agent-web/src/main/java/software/amazon/disco/agent/web/apache/httpclient/ApacheHttpClientInterceptor.java
+++ b/disco-java-agent-web/src/main/java/software/amazon/disco/agent/web/apache/httpclient/ApacheHttpClientInterceptor.java
@@ -215,9 +215,8 @@ public class ApacheHttpClientInterceptor implements Installable {
      */
     static ElementMatcher<? super TypeDescription> buildClassMatcher() {
         ElementMatcher.Junction<TypeDescription> classMatches = ElementMatchers.hasSuperType(ElementMatchers.named("org.apache.http.client.HttpClient"));
-        ElementMatcher.Junction<ModifierReviewable.OfAbstraction> notAbstractClassMatches = ElementMatchers.not(ElementMatchers.isAbstract());
         ElementMatcher.Junction<TypeDescription> notInterfaceMatches = ElementMatchers.not(ElementMatchers.isInterface());
-        return classMatches.and(notInterfaceMatches).and(notAbstractClassMatches);
+        return classMatches.and(notInterfaceMatches);
     }
 
     /**

--- a/disco-java-agent-web/src/test/java/software/amazon/disco/agent/web/apache/httpclient/ApacheHttpClientInterceptorTests.java
+++ b/disco-java-agent-web/src/test/java/software/amazon/disco/agent/web/apache/httpclient/ApacheHttpClientInterceptorTests.java
@@ -15,6 +15,7 @@
 
 package software.amazon.disco.agent.web.apache.httpclient;
 
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import software.amazon.disco.agent.concurrent.TransactionContext;
 import software.amazon.disco.agent.event.Event;
@@ -109,6 +110,11 @@ public class ApacheHttpClientInterceptorTests {
     }
 
     @Test
+    public void testClassMatcherSucceedsOnAbstractClass() {
+        assertTrue(classMatches(CloseableHttpClient.class));
+    }
+
+    @Test
     public void testClassMatcherSucceededOnConcreteClass() {
         assertTrue(classMatches(SomeChainedExecuteMethodsHttpClient.class));
     }
@@ -129,6 +135,16 @@ public class ApacheHttpClientInterceptorTests {
     @Test
     public void testMethodMatcherSucceeded() throws Exception {
         assertEquals(11, methodMatchedCount("execute", SomeChainedExecuteMethodsHttpClient.class));
+    }
+
+    @Test
+    public void testMethodMatcherSucceededOnAbstractClassButConcreteMethod() throws Exception {
+        assertEquals(12, methodMatchedCount("execute", CloseableHttpClient.class));
+    }
+
+    @Test(expected = NoSuchMethodException.class)
+    public void testMethodMatcherFailedOnConcreteClassButNoTargetedMethodImpl() throws Exception {
+        methodMatchedCount("execute", HttpClients.createMinimal().getClass());
     }
 
     @Test


### PR DESCRIPTION
This shall capture cases like `CloseableHttpClient` as an abstract class implements `execute` methods while its concrete class `MinimalHttpClient` doesn't

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
