### PR TITLE
Added new Bootstrap classpath loading strategy for DiscoAgent

### DIFF
--- a/disco-java-agent/disco-java-agent-core/src/main/java/software/amazon/disco/agent/plugin/PluginDiscovery.java
+++ b/disco-java-agent/disco-java-agent-core/src/main/java/software/amazon/disco/agent/plugin/PluginDiscovery.java
@@ -113,11 +113,12 @@ public class PluginDiscovery {
             File[] files = pluginDir.listFiles();
             if (files != null) {
                 for (File jarFile : files) {
-                    if (jarFile.getName().substring(jarFile.getName().lastIndexOf(".")).equalsIgnoreCase(".jar")) {
+                    int dotIndex = jarFile.getName().lastIndexOf(".");
+                    if (dotIndex != -1 && jarFile.getName().substring(dotIndex).equalsIgnoreCase(".jar")) {
                         processJarFile(instrumentation, jarFile, config.isRuntimeOnly());
                     } else {
                         //ignore non JAR file
-                        log.info("DiSCo(Core) non JAR file found on plugin path, skipping this file");
+                        log.info("DiSCo(Core) directory or non JAR file found on plugin path, skipping it");
                     }
                 }
             }

--- a/disco-java-agent/disco-java-agent/build.gradle.kts
+++ b/disco-java-agent/disco-java-agent/build.gradle.kts
@@ -24,16 +24,12 @@ dependencies {
 }
 
 tasks.shadowJar  {
-    //suppress the "-all" suffix on the jar name, simply replace the default built jar instead (e.g. disco-java-agent-0.1.jar)
-    archiveClassifier.set(null as String?)
-
     manifest {
         attributes(mapOf(
                 "Premain-Class" to "software.amazon.disco.agent.DiscoAgent",
                 "Agent-Class" to "software.amazon.disco.agent.DiscoAgent",
                 "Can-Redefine-Classes" to "true",
-                "Can-Retransform-Classes" to "true",
-                "Boot-Class-Path" to archiveFileName.get()
+                "Can-Retransform-Classes" to "true"
         ))
     }
 }

--- a/disco-java-agent/disco-java-agent/src/main/java/software/amazon/disco/agent/DiscoAgent.java
+++ b/disco-java-agent/disco-java-agent/src/main/java/software/amazon/disco/agent/DiscoAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").
  *   You may not use this file except in compliance with the License.
@@ -15,29 +15,42 @@
 
 package software.amazon.disco.agent;
 
-import software.amazon.disco.agent.concurrent.ConcurrencySupport;
-import software.amazon.disco.agent.config.AgentConfig;
-import software.amazon.disco.agent.logging.LogManager;
-import software.amazon.disco.agent.logging.Logger;
-import software.amazon.disco.agent.plugin.PluginOutcome;
+import software.amazon.disco.agent.inject.Injector;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.lang.instrument.Instrumentation;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.CodeSource;
+import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * Canonical 'empty' agent used as a vessel for discovered plugins. Unless building a monolithic agent for a site-specific
- * purpose, it is usually desirable to have a singular disco agent acting as a substrate, with lightweight discoverable plugins
- * containing interception treatments expressed as Installables (see disco-java-agent-web-plugin for an example), and implementation
- * of products (such as loggers, or context propagation features for your site) in the form of Listeners.
+ * Entry class for the Disco substrate agent. This class is loaded with the System class loader by the JVM, but we want
+ * to be in the bootstrap classloader to perform instrumentation. So all we do here is:
  *
- * It is expected that the agent jar file is configured with an appropriate Manifest, specifying the Boot-Class-Path accordingly
- * since the core concurrency treatments are inoperable otherwise. See this module's build.gradle.kts.
+ * 1. Load the shaded JAR containing the proper DiscoBootstrapAgent class and ByteBuddy dependencies to the bootstrap
+ * classpath if it's not already there (e.g. by usage of the Inject API)
+ * 2. Load the "real" DiscoBootstrapAgent class
+ * 3. Jump over to the real agent class to initialize DiSCo, load plugins, etc
+ *
+ * This class should be kept as minimal as possible to avoid loading classes before we have a chance to instrument them.
+ *
+ * Adapted under the Apache 2.0 license from the OpenTelemetry Agent:
+ * https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/javaagent/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
  */
 public class DiscoAgent {
-    private static Logger log = LogManager.getLogger(DiscoAgent.class);
+    private static final Class<?> thisClass = DiscoAgent.class;
+
     /**
      * Entry point when agent is loaded from the command line via a "-javaagent" argument. This is also the method called when
      * sideloading an agent via disco-java-agent-inject-api, such as is necessary in AWS Lambda installations.
@@ -65,66 +78,152 @@ public class DiscoAgent {
         impl(agentArgs, instrumentation);
     }
 
-    /**
-     * Common implementation delegated to by both the premain() and agentmain() methods.
-     *
-     * @param agentArgs arguments which are passed to disco's core for configuration. Generally speaking this necessitates
-     *                  passing a 'pluginPath' argument, so that disco knows where to find its extensions. Without this argument
-     *                  the agent performs thread hand-off housekeeping, but is otherwise a no-op. See AgentConfigParser for
-     *                  other available options
-     * @param instrumentation an Instrumentation instance provided by the Java runtime, to allow bytecode manipulations
-     */
     private static void impl(String agentArgs, Instrumentation instrumentation) {
-        log.info("DiSCo(Agent) starting agent");
-        DiscoAgentTemplate agent = new DiscoAgentTemplate(agentArgs);
+        try {
+            // A null classloader represents the bootstrap classloader, meaning this class is already on the bootstrap
+            // classpath. This is possible if the DiSCo agent is loaded via the Inject API rather than from the command
+            // line, which appends the agent JAR to the bootstrap class path search before invoking premain.
+            // https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getClassLoader--
+            if (thisClass.getClassLoader() != null) {
+                installBootstrapJar(instrumentation);
+            }
 
-        AgentConfig config = agent.getConfig();
-        if (config.getPluginPath() == null) {
-            log.warn("DiSCo(Agent) no pluginPath configured, agent is effectively inert. Are you sure that's what you intended?");
+            Class<?> agentInitializerClass =
+                    ClassLoader.getSystemClassLoader()
+                            .loadClass("software.amazon.disco.agent.bootstrap.DiscoBootstrapAgent");
+            Method startMethod =
+                    agentInitializerClass.getMethod("initialize", String.class, Instrumentation.class);
+            startMethod.invoke(null, agentArgs, instrumentation);
+        } catch (Throwable ex) {
+            // Don't rethrow.  We don't have a log manager here, so just print.
+            System.err.println("DiSCo(Agent) ERROR: " + thisClass.getName());
+            ex.printStackTrace();
         }
-
-        //if forking this canonical agent to build a site specific variant, you may wish to provide a custom ignore-matcher
-        //to the install() method, if you have commonly used internal software which benefits from being 'avoided' by the
-        //installed interceptions. e.g.:
-
-        //ElementMatcher myIgnoreMatcher = ElementMatchers.named("com.my.organization.some.problematic.class.TheClass");
-        Collection<PluginOutcome> outcomes = agent.install(instrumentation, new HashSet<>(new ConcurrencySupport().get())/*, myIgnoreMatcher */);
-        dump(outcomes);
-
-        log.info("DiSCo(Agent) agent startup complete");
     }
 
     /**
-     * As a debugging courtesy, we dump to any configured Logger what the agent installed and discovered. By default
-     * no logger is installed unless either specified on the command line, or explicitly given by a custom fork of this
-     * agent code.
+     * This method attempts to retrieve the JAR file that contains this class (and the rest of the DiSCo Java agent),
+     * first by using {@link CodeSource}, and second by parsing the JVM arguments, from
      *
-     * @param outcomes the summary of outcomes produced by the Plugin Discovery subsystem.
+     * @param inst an Instrumentation instance provided by the Java runtime, to allow bytecode manipulations
+     * @throws IOException if Jar File isn't found
+     * @throws URISyntaxException if Jar File is invalid
      */
-    private static void dump(Collection<PluginOutcome> outcomes) {
-        for (PluginOutcome outcome: outcomes) {
-            StringBuilder builder = new StringBuilder();
-            builder.append("DiSCo(Agent) Plugin name: ").append(outcome.name).append("\n");
+    private static synchronized void installBootstrapJar(Instrumentation inst)
+            throws IOException, URISyntaxException {
 
-            builder.append("\tBootstrap: ").append(outcome.bootstrap ? "yes" : "no").append("\n");
+        URL javaAgentJarURL;
 
-            if (outcome.initClass != null) {
-                builder.append("\tInit: ").append(outcome.initClass.getName()).append("\n");
+        // First try Code Source
+        CodeSource codeSource = thisClass.getProtectionDomain().getCodeSource();
+
+        if (codeSource != null) {
+            javaAgentJarURL = codeSource.getLocation();
+            File bootstrapFile = new File(javaAgentJarURL.toURI());
+
+            if (!bootstrapFile.isDirectory()) {
+                checkJarManifestPremainClassIsThis(javaAgentJarURL);
+                Injector.addToBootstrapClasspath(inst, bootstrapFile);
+                return;
             }
-
-            if (outcome.installables != null && !outcome.installables.isEmpty()) {
-                List<String> installableStrings = new ArrayList<>(outcome.installables.size());
-                outcome.installables.forEach(i -> installableStrings.add(i.getClass().getName()));
-                builder.append("\tInstallables: ").append(String.join(", ", installableStrings.toArray(new String[0]))).append("\n");
-            }
-
-            if (outcome.listeners != null && !outcome.listeners.isEmpty()) {
-                List<String> listenerStrings = new ArrayList<>(outcome.listeners.size());
-                outcome.listeners.forEach(l -> listenerStrings.add(l.getClass().getName()));
-                builder.append("\tListeners: ").append(String.join(", ", listenerStrings.toArray(new String[0]))).append("\n");
-            }
-
-            log.info(builder.toString());
         }
+
+        System.out.println("DiSCo(Agent) Could not get bootstrap jar from code source, using -javaagent arg");
+
+        // ManagementFactory indirectly references java.util.logging.LogManager
+        // - On Oracle-based JDKs after 1.8
+        // - On IBM-based JDKs since at least 1.7
+        // This prevents custom log managers from working correctly
+        // Use reflection to bypass the loading of the class
+        List<String> arguments = getVMArgumentsThroughReflection();
+
+        String agentArgument = null;
+        for (String arg : arguments) {
+            if (arg.startsWith("-javaagent")) {
+                if (agentArgument == null) {
+                    agentArgument = arg;
+                } else {
+                    throw new RuntimeException(
+                            "Multiple javaagents specified and code source unavailable, not installing DiSCo agent");
+                }
+            }
+        }
+
+        if (agentArgument == null) {
+            throw new RuntimeException(
+                    "Could not find javaagent parameter and code source unavailable, not installing DiSCo agent");
+        }
+
+        // argument is of the form -javaagent:/path/to/java-agent.jar=optionalargumentstring
+        Matcher matcher = Pattern.compile("-javaagent:([^=]+).*").matcher(agentArgument);
+
+        if (!matcher.matches()) {
+            throw new RuntimeException("Unable to parse javaagent parameter: " + agentArgument);
+        }
+
+        File javaagentFile = new File(matcher.group(1));
+        if (!(javaagentFile.exists() || javaagentFile.isFile())) {
+            throw new RuntimeException("Unable to find javaagent file: " + javaagentFile);
+        }
+        javaAgentJarURL = javaagentFile.toURI().toURL();
+        checkJarManifestPremainClassIsThis(javaAgentJarURL);
+        Injector.addToBootstrapClasspath(inst, javaagentFile);
+    }
+
+    private static List<String> getVMArgumentsThroughReflection() {
+        try {
+            // Try Oracle-based
+            Class managementFactoryHelperClass =
+                    thisClass.getClassLoader().loadClass("sun.management.ManagementFactoryHelper");
+
+            Class vmManagementClass = thisClass.getClassLoader().loadClass("sun.management.VMManagement");
+
+            Object vmManagement;
+
+            try {
+                vmManagement =
+                        managementFactoryHelperClass.getDeclaredMethod("getVMManagement").invoke(null);
+            } catch (NoSuchMethodException e) {
+                // Older vm before getVMManagement() existed
+                Field field = managementFactoryHelperClass.getDeclaredField("jvm");
+                field.setAccessible(true);
+                vmManagement = field.get(null);
+                field.setAccessible(false);
+            }
+
+            return (List<String>) vmManagementClass.getMethod("getVmArguments").invoke(vmManagement);
+
+        } catch (ReflectiveOperationException e) {
+            try { // Try IBM-based.
+                Class VMClass = thisClass.getClassLoader().loadClass("com.ibm.oti.vm.VM");
+                String[] argArray = (String[]) VMClass.getMethod("getVMArgs").invoke(null);
+                return Arrays.asList(argArray);
+            } catch (ReflectiveOperationException e1) {
+                // Fallback to default
+                System.out.println("DiSCo(Agent) WARNING: Unable to get VM args through reflection. " +
+                                "A custom java.util.logging.LogManager may not work correctly");
+
+                return ManagementFactory.getRuntimeMXBean().getInputArguments();
+            }
+        }
+    }
+
+    private static boolean checkJarManifestPremainClassIsThis(URL jarUrl) throws IOException {
+        URL manifestUrl = new URL("jar:" + jarUrl + "!/META-INF/MANIFEST.MF");
+        String premainClassLine = "Premain-Class: " + thisClass.getCanonicalName();
+        try (BufferedReader reader =
+                     new BufferedReader(
+                             new InputStreamReader(manifestUrl.openStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.equals(premainClassLine)) {
+                    return true;
+                }
+            }
+        }
+        throw new RuntimeException(
+                "The DiSCo Agent cannot be installed, because class '"
+                        + thisClass.getCanonicalName() + "' is located in '" + jarUrl
+                        + "'. Make sure you don't have this .class file anywhere, besides in the disco-java-agent JAR");
     }
 }

--- a/disco-java-agent/disco-java-agent/src/main/java/software/amazon/disco/agent/bootstrap/DiscoBootstrapAgent.java
+++ b/disco-java-agent/disco-java-agent/src/main/java/software/amazon/disco/agent/bootstrap/DiscoBootstrapAgent.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package software.amazon.disco.agent.bootstrap;
+
+import software.amazon.disco.agent.DiscoAgentTemplate;
+import software.amazon.disco.agent.concurrent.ConcurrencySupport;
+import software.amazon.disco.agent.config.AgentConfig;
+import software.amazon.disco.agent.logging.LogManager;
+import software.amazon.disco.agent.logging.Logger;
+import software.amazon.disco.agent.plugin.PluginOutcome;
+
+import java.lang.instrument.Instrumentation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * Canonical 'empty' agent used as a vessel for discovered plugins. Unless building a monolithic agent for a site-specific
+ * purpose, it is usually desirable to have a singular disco agent acting as a substrate, with lightweight discoverable plugins
+ * containing interception treatments expressed as Installables (see disco-java-agent-web-plugin for an example), and implementation
+ * of products (such as loggers, or context propagation features for your site) in the form of Listeners.
+ *
+ * It is expected that the agent jar file is configured with an appropriate Manifest, specifying the Boot-Class-Path accordingly
+ * since the core concurrency treatments are inoperable otherwise. See this module's build.gradle.kts.
+ */
+public class DiscoBootstrapAgent {
+    private static Logger log = LogManager.getLogger(DiscoBootstrapAgent.class);
+
+    /**
+     * Common implementation delegated to by both the premain() and agentmain() methods.
+     *
+     * @param agentArgs arguments which are passed to disco's core for configuration. Generally speaking this necessitates
+     *                  passing a 'pluginPath' argument, so that disco knows where to find its extensions. Without this argument
+     *                  the agent performs thread hand-off housekeeping, but is otherwise a no-op. See AgentConfigParser for
+     *                  other available options
+     * @param instrumentation an Instrumentation instance provided by the Java runtime, to allow bytecode manipulations
+     */
+    public static void initialize(String agentArgs, Instrumentation instrumentation) {
+        log.info("DiSCo(Agent) starting agent");
+        DiscoAgentTemplate agent = new DiscoAgentTemplate(agentArgs);
+
+        AgentConfig config = agent.getConfig();
+        if (config.getPluginPath() == null) {
+            log.warn("DiSCo(Agent) no pluginPath configured, agent is effectively inert. Are you sure that's what you intended?");
+        }
+
+        //if forking this canonical agent to build a site specific variant, you may wish to provide a custom ignore-matcher
+        //to the install() method, if you have commonly used internal software which benefits from being 'avoided' by the
+        //installed interceptions. e.g.:
+
+        //ElementMatcher myIgnoreMatcher = ElementMatchers.named("com.my.organization.some.problematic.class.TheClass");
+        Collection<PluginOutcome> outcomes = agent.install(instrumentation, new HashSet<>(new ConcurrencySupport().get())/*, myIgnoreMatcher */);
+        dump(outcomes);
+
+        log.info("DiSCo(Agent) agent startup complete");
+    }
+
+    /**
+     * As a debugging courtesy, we dump to any configured Logger what the agent installed and discovered. By default
+     * no logger is installed unless either specified on the command line, or explicitly given by a custom fork of this
+     * agent code.
+     *
+     * @param outcomes the summary of outcomes produced by the Plugin Discovery subsystem.
+     */
+    private static void dump(Collection<PluginOutcome> outcomes) {
+        for (PluginOutcome outcome: outcomes) {
+            StringBuilder builder = new StringBuilder();
+            builder.append("DiSCo(Agent) Plugin name: ").append(outcome.name).append("\n");
+
+            builder.append("\tBootstrap: ").append(outcome.bootstrap ? "yes" : "no").append("\n");
+
+            if (outcome.initClass != null) {
+                builder.append("\tInit: ").append(outcome.initClass.getName()).append("\n");
+            }
+
+            if (outcome.installables != null && !outcome.installables.isEmpty()) {
+                List<String> installableStrings = new ArrayList<>(outcome.installables.size());
+                outcome.installables.forEach(i -> installableStrings.add(i.getClass().getName()));
+                builder.append("\tInstallables: ").append(String.join(", ", installableStrings.toArray(new String[0]))).append("\n");
+            }
+
+            if (outcome.listeners != null && !outcome.listeners.isEmpty()) {
+                List<String> listenerStrings = new ArrayList<>(outcome.listeners.size());
+                outcome.listeners.forEach(l -> listenerStrings.add(l.getClass().getName()));
+                builder.append("\tListeners: ").append(String.join(", ", listenerStrings.toArray(new String[0]))).append("\n");
+            }
+
+            log.info(builder.toString());
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
I removed the `Boot-Class-Path` attribute from the `disco-java-agent`'s manifest, and introduced a new Bootstrap injection strategy for the substrate DiscoAgent to replace it. The new approach is inspired directly from the OpenTelemetry Java Agent, and in short it uses a minimal agent class `DiscoAgent`, as the premain class. `DiscoAgent` then adds the entire `disco-java-agent.jar` file to the bootstrap classpath, as was done before, then jumps over to the original agent class (now `DiscoBootstrapAgent`) to perform the expected work.

I need to add some more JavaDoc and update the readme, but I chiefly wanted to make sure this strategy was acceptable before polishing it off. I think removing the jar name from the manifest will save much pain down the road.

Also removed some redundancy from Disco agent's build.gradle and fixed a `StringIndexOutOfBoundsException` that happened if there's a directory in your `pluginPath`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
