### PR TITLE
Build and test disco using multiple JDKs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,17 +1,21 @@
 name: Java CI
 
-on: [push]
+on: [pull_request, push]
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        java-version: [8, 11]
+
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: ${{ matrix.java-version }}
     - name: Build with Gradle
       run: ./gradlew build --info --stacktrace --continue


### PR DESCRIPTION
JDK8 and 11 are supported. JDK17 build, however, is still failing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
