### PR TITLE
Upgrade log4j to the latest 2.17.2

### DIFF
--- a/disco-java-agent-instrumentation-preprocess/build.gradle.kts
+++ b/disco-java-agent-instrumentation-preprocess/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     compileOnly(project(":disco-java-agent:disco-java-agent-core"))
     compileOnly(project(":disco-java-agent:disco-java-agent-api"))
     implementation(project(":disco-java-agent:disco-java-agent-inject-api"))
-    implementation("org.apache.logging.log4j", "log4j-core", "2.13.3")
+    implementation("org.apache.logging.log4j", "log4j-core", "2.17.2")
 
     testImplementation(project(":disco-java-agent:disco-java-agent-core"))
     testImplementation(project(":disco-java-agent:disco-java-agent-api"))


### PR DESCRIPTION
*Description of changes:* log4j-core-2.13.3 has some vulnerabilities https://cwe.mitre.org/data/definitions/502.html and https://nvd.nist.gov/vuln/detail/CVE-2021-44228 so we want to use the latest version of 2.17.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
